### PR TITLE
allow passing lambdas to eval task builder without casting

### DIFF
--- a/examples/src/main/java/dev/braintrust/examples/ExperimentExample.java
+++ b/examples/src/main/java/dev/braintrust/examples/ExperimentExample.java
@@ -41,7 +41,7 @@ public class ExperimentExample {
                                 EvalCase.of("asparagus", "vegetable"),
                                 EvalCase.of("apple", "fruit"),
                                 EvalCase.of("banana", "fruit"))
-                        .task(getFoodType)
+                        .taskFunction(getFoodType)
                         .scorers(
                                 Scorer.of(
                                         "fruit_scorer",

--- a/src/main/java/dev/braintrust/eval/Eval.java
+++ b/src/main/java/dev/braintrust/eval/Eval.java
@@ -250,8 +250,8 @@ public final class Eval<INPUT, OUTPUT> {
             return this;
         }
 
-        public Builder<INPUT, OUTPUT> task(Function<INPUT, OUTPUT> taskFn) {
-            return task((Task<INPUT, OUTPUT>) evalCase -> taskFn.apply(evalCase.input()));
+        public Builder<INPUT, OUTPUT> taskFunction(Function<INPUT, OUTPUT> taskFn) {
+            return task(evalCase -> taskFn.apply(evalCase.input()));
         }
 
         @SafeVarargs

--- a/src/test/java/dev/braintrust/eval/EvalTest.java
+++ b/src/test/java/dev/braintrust/eval/EvalTest.java
@@ -6,7 +6,6 @@ import dev.braintrust.TestHarness;
 import dev.braintrust.api.BraintrustApiClient;
 import dev.braintrust.trace.BraintrustTracing;
 import io.opentelemetry.api.common.AttributeKey;
-import java.util.function.Function;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -30,7 +29,7 @@ public class EvalTest {
                         .cases(
                                 EvalCase.of("strawberry", "fruit"),
                                 EvalCase.of("asparagus", "vegetable"))
-                        .task((Function<String, String>) food -> "fruit")
+                        .task(food -> "fruit")
                         .scorers(
                                 Scorer.of(
                                         "fruit_scorer",


### PR DESCRIPTION
move the overloaded task method to `taskFunction`. This allows for passing lambdas to the eval builder without explicit casting