### PR TITLE
support Datasets and additional output date in Evals

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,9 @@ Function<String, String> getFoodType =
 var eval = braintrust.<String, String>evalBuilder()
                 .name("java-eval-x-" + System.currentTimeMillis())
                 .cases(
-                        EvalCase.of("asparagus", "vegetable"),
-                        EvalCase.of("banana", "fruit"))
-                .task(getFoodType)
+                        DatasetCase.of("asparagus", "vegetable"),
+                        DatasetCase.of("banana", "fruit"))
+                .taskFunction(getFoodType)
                 .scorers(
                         Scorer.of(
                                 "fruit_scorer",

--- a/examples/src/main/java/dev/braintrust/examples/ExperimentExample.java
+++ b/examples/src/main/java/dev/braintrust/examples/ExperimentExample.java
@@ -4,7 +4,7 @@ import com.openai.client.okhttp.OpenAIOkHttpClient;
 import com.openai.models.ChatModel;
 import com.openai.models.chat.completions.ChatCompletionCreateParams;
 import dev.braintrust.Braintrust;
-import dev.braintrust.eval.EvalCase;
+import dev.braintrust.eval.DatasetCase;
 import dev.braintrust.eval.Scorer;
 import dev.braintrust.instrumentation.openai.BraintrustOpenAI;
 import java.util.function.Function;
@@ -37,10 +37,10 @@ public class ExperimentExample {
                         // will append new cases to
                         // the same experiment
                         .cases(
-                                EvalCase.of("strawberry", "fruit"),
-                                EvalCase.of("asparagus", "vegetable"),
-                                EvalCase.of("apple", "fruit"),
-                                EvalCase.of("banana", "fruit"))
+                                DatasetCase.of("strawberry", "fruit"),
+                                DatasetCase.of("asparagus", "vegetable"),
+                                DatasetCase.of("apple", "fruit"),
+                                DatasetCase.of("banana", "fruit"))
                         .taskFunction(getFoodType)
                         .scorers(
                                 Scorer.of(

--- a/src/main/java/dev/braintrust/eval/Dataset.java
+++ b/src/main/java/dev/braintrust/eval/Dataset.java
@@ -1,0 +1,42 @@
+package dev.braintrust.eval;
+
+import java.util.List;
+import java.util.Optional;
+import javax.annotation.concurrent.NotThreadSafe;
+
+/**
+ * Datasets define the cases for evals. This interface provides a means of iterating through all
+ * cases of a particular dataset.
+ *
+ * <p>The most common implementations are in-memory datasets, and datasets fetched from the
+ * Braintrust API.
+ */
+public interface Dataset<INPUT, OUTPUT> {
+    Cursor<DatasetCase<INPUT, OUTPUT>> openCursor();
+
+    String id();
+
+    String version();
+
+    @NotThreadSafe
+    interface Cursor<CASE> extends AutoCloseable {
+        /**
+         * Fetch the next case. Returns empty if there are no more cases to fetch.
+         *
+         * <p>Implementations may make external requests to fetch data.
+         *
+         * <p>If this method is invoked after {@link #close()} an IllegalStateException will be
+         * thrown
+         */
+        Optional<CASE> next();
+
+        /** close all cursor resources */
+        void close();
+    }
+
+    /** Create an in-memory Dataset containing the provided cases. */
+    @SafeVarargs
+    static <INPUT, OUTPUT> Dataset<INPUT, OUTPUT> of(DatasetCase<INPUT, OUTPUT>... cases) {
+        return new DatasetInMemoryImpl<>(List.of(cases));
+    }
+}

--- a/src/main/java/dev/braintrust/eval/DatasetCase.java
+++ b/src/main/java/dev/braintrust/eval/DatasetCase.java
@@ -1,0 +1,25 @@
+package dev.braintrust.eval;
+
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nonnull;
+
+/** A single row in a dataset. */
+public record DatasetCase<INPUT, OUTPUT>(
+        INPUT input,
+        OUTPUT expected,
+        @Nonnull List<String> tags,
+        @Nonnull Map<String, Object> metadata) {
+    public DatasetCase {
+        if (!metadata.isEmpty()) {
+            throw new RuntimeException("TODO: metadata support not yet implemented");
+        }
+        if (!tags.isEmpty()) {
+            throw new RuntimeException("TODO: tags support not yet implemented");
+        }
+    }
+
+    public static <INPUT, OUTPUT> DatasetCase<INPUT, OUTPUT> of(INPUT input, OUTPUT expected) {
+        return new DatasetCase<>(input, expected, List.of(), Map.of());
+    }
+}

--- a/src/main/java/dev/braintrust/eval/DatasetInMemoryImpl.java
+++ b/src/main/java/dev/braintrust/eval/DatasetInMemoryImpl.java
@@ -1,0 +1,49 @@
+package dev.braintrust.eval;
+
+import java.util.List;
+import java.util.Optional;
+
+/** A dataset held entirely in memory */
+class DatasetInMemoryImpl<INPUT, OUTPUT> implements Dataset<INPUT, OUTPUT> {
+    private final List<DatasetCase<INPUT, OUTPUT>> cases;
+    private final String id;
+
+    DatasetInMemoryImpl(List<DatasetCase<INPUT, OUTPUT>> cases) {
+        this.cases = List.copyOf(cases);
+        id = "in-memory-dataset<" + this.cases.hashCode() + ">";
+    }
+
+    @Override
+    public String id() {
+        return id;
+    }
+
+    @Override
+    public String version() {
+        return "0";
+    }
+
+    @Override
+    public Cursor<DatasetCase<INPUT, OUTPUT>> openCursor() {
+        return new Cursor<>() {
+            int nextIndex = 0;
+            boolean closed = false;
+
+            @Override
+            public Optional<DatasetCase<INPUT, OUTPUT>> next() {
+                if (closed) {
+                    throw new IllegalStateException("this method may not be invoked after close");
+                } else if (nextIndex < cases.size()) {
+                    return Optional.of(cases.get(nextIndex++));
+                } else {
+                    return Optional.empty();
+                }
+            }
+
+            @Override
+            public void close() {
+                closed = true;
+            }
+        };
+    }
+}

--- a/src/main/java/dev/braintrust/eval/EvalCase.java
+++ b/src/main/java/dev/braintrust/eval/EvalCase.java
@@ -4,19 +4,15 @@ import java.util.List;
 import java.util.Map;
 import javax.annotation.Nonnull;
 
-/**
- * A single test case in an LLM eval.
- *
- * @param input test input
- * @param expected expected value
- * @param tags additional tags to apply in the braintrust UI
- * @param metadata additional key-value data to apply in the braintrust UI
- */
+/** Deprecated. Use {@link DatasetCase} instead */
+@Deprecated
 public record EvalCase<INPUT, OUTPUT>(
         INPUT input,
         OUTPUT expected,
         @Nonnull List<String> tags,
         @Nonnull Map<String, Object> metadata) {
+    /** Deprecated. Use {@link DatasetCase} instead */
+    @Deprecated
     public EvalCase {
         if (!metadata.isEmpty()) {
             throw new RuntimeException("TODO: metadata support not yet implemented");
@@ -26,10 +22,14 @@ public record EvalCase<INPUT, OUTPUT>(
         }
     }
 
+    /** Deprecated. Use {@link DatasetCase} instead */
+    @Deprecated
     public static <INPUT, OUTPUT> EvalCase<INPUT, OUTPUT> of(INPUT input, OUTPUT expected) {
         return of(input, expected, List.of(), Map.of());
     }
 
+    /** Deprecated. Use {@link DatasetCase} instead */
+    @Deprecated
     public static <INPUT, OUTPUT> EvalCase<INPUT, OUTPUT> of(
             INPUT input,
             OUTPUT expected,
@@ -38,5 +38,11 @@ public record EvalCase<INPUT, OUTPUT>(
         return new EvalCase<>(input, expected, tags, metadata);
     }
 
-    public record Result<INPUT, OUTPUT>(EvalCase<INPUT, OUTPUT> evalCase, OUTPUT result) {}
+    static <INPUT, OUTPUT> EvalCase<INPUT, OUTPUT> from(DatasetCase<INPUT, OUTPUT> datasetCase) {
+        return new EvalCase<>(
+                datasetCase.input(),
+                datasetCase.expected(),
+                datasetCase.tags(),
+                datasetCase.metadata());
+    }
 }

--- a/src/main/java/dev/braintrust/eval/EvalResult.java
+++ b/src/main/java/dev/braintrust/eval/EvalResult.java
@@ -1,0 +1,18 @@
+package dev.braintrust.eval;
+
+import lombok.Getter;
+import lombok.SneakyThrows;
+
+/** Results of all eval cases of an experiment. */
+public class EvalResult {
+    @Getter private final String experimentUrl;
+
+    @SneakyThrows
+    EvalResult(String experimentUrl) {
+        this.experimentUrl = experimentUrl;
+    }
+
+    public String createReportString() {
+        return "Experiment complete. View results in braintrust: %s".formatted(experimentUrl);
+    }
+}

--- a/src/main/java/dev/braintrust/eval/Score.java
+++ b/src/main/java/dev/braintrust/eval/Score.java
@@ -1,0 +1,18 @@
+package dev.braintrust.eval;
+
+/** Individual metric value assigned by a scorer. */
+public record Score(
+        /**
+         * Name of the metric being scored.
+         *
+         * <p>This does not have to be the same as the scorer name, but it often will be.
+         */
+        String name,
+        /**
+         * Numeric representation of how well the task performed.
+         *
+         * <p>Must be between 0.0 (inclusive) and 1.0 (inclusive)
+         *
+         * <p>0 is completely incorrect. 1 is completely correct.
+         */
+        double value) {}

--- a/src/main/java/dev/braintrust/eval/Task.java
+++ b/src/main/java/dev/braintrust/eval/Task.java
@@ -7,5 +7,5 @@ package dev.braintrust.eval;
  * @param <OUTPUT> type of the output data
  */
 public interface Task<INPUT, OUTPUT> {
-    OUTPUT apply(EvalCase<INPUT, OUTPUT> evalCase);
+    TaskResult<INPUT, OUTPUT> apply(DatasetCase<INPUT, OUTPUT> datasetCase);
 }

--- a/src/main/java/dev/braintrust/eval/TaskResult.java
+++ b/src/main/java/dev/braintrust/eval/TaskResult.java
@@ -1,0 +1,8 @@
+package dev.braintrust.eval;
+
+/** Result from a single task run. */
+public record TaskResult<INPUT, OUTPUT>(
+        /** task output */
+        OUTPUT result,
+        /** The dataset case the task ran against to produce the result */
+        DatasetCase<INPUT, OUTPUT> datasetCase) {}

--- a/src/test/java/dev/braintrust/eval/EvalTest.java
+++ b/src/test/java/dev/braintrust/eval/EvalTest.java
@@ -6,6 +6,11 @@ import dev.braintrust.TestHarness;
 import dev.braintrust.api.BraintrustApiClient;
 import dev.braintrust.trace.BraintrustTracing;
 import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.trace.SpanId;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import lombok.SneakyThrows;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -18,6 +23,7 @@ public class EvalTest {
     }
 
     @Test
+    @SneakyThrows
     public void evalOtelTraceWithProperAttributes() {
         var experimentName = "unit-test-eval";
 
@@ -27,9 +33,9 @@ public class EvalTest {
                         .<String, String>evalBuilder()
                         .name(experimentName)
                         .cases(
-                                EvalCase.of("strawberry", "fruit"),
-                                EvalCase.of("asparagus", "vegetable"))
-                        .task(food -> "fruit")
+                                DatasetCase.of("strawberry", "fruit"),
+                                DatasetCase.of("asparagus", "vegetable"))
+                        .taskFunction(food -> "fruit")
                         .scorers(
                                 Scorer.of(
                                         "fruit_scorer",
@@ -44,8 +50,6 @@ public class EvalTest {
                         .formatted(testHarness.braintrust().projectUri(), experimentName),
                 result.getExperimentUrl());
         var spans = testHarness.awaitExportedSpans();
-        assertEquals(6, spans.size(), "each eval case should make three spans");
-        // TODO: assert each case makes the expected spans
         var experiment =
                 testHarness
                         .braintrust()
@@ -53,15 +57,46 @@ public class EvalTest {
                         .getOrCreateExperiment(
                                 new BraintrustApiClient.CreateExperimentRequest(
                                         TestHarness.defaultProjectId(), experimentName));
-        spans.forEach(
-                span -> {
-                    var parent =
-                            span.getAttributes()
-                                    .get(AttributeKey.stringKey(BraintrustTracing.PARENT_KEY));
-                    assertEquals(
-                            "experiment_id:" + experiment.id(),
-                            parent,
-                            "all eval spans must set the parent to the experiment id");
-                });
+        final AtomicInteger numRootSpans = new AtomicInteger(0);
+        for (SpanData span : spans) {
+            var parent =
+                    span.getAttributes().get(AttributeKey.stringKey(BraintrustTracing.PARENT_KEY));
+            assertEquals(
+                    "experiment_id:" + experiment.id(),
+                    parent,
+                    "all eval spans must set the parent to the experiment id");
+            if (span.getParentSpanId().equals(SpanId.getInvalid())) {
+                numRootSpans.incrementAndGet();
+                var inputJson =
+                        Eval.JSON_MAPPER.readValue(
+                                span.getAttributes()
+                                        .get(AttributeKey.stringKey("braintrust.input_json")),
+                                Map.class);
+                assertNotNull(inputJson.get("input"), "invlaid input: " + inputJson);
+
+                var expected =
+                        Eval.JSON_MAPPER.readValue(
+                                span.getAttributes()
+                                        .get(AttributeKey.stringKey("braintrust.expected")),
+                                String.class);
+                assertTrue(isFruitOrVegetable(expected), "invalid expected: " + expected);
+
+                var outputJson =
+                        Eval.JSON_MAPPER.readValue(
+                                span.getAttributes()
+                                        .get(AttributeKey.stringKey("braintrust.output_json")),
+                                Map.class);
+                var output = outputJson.get("output");
+                assertNotNull(output, "invlaid output: " + outputJson);
+                assertTrue(isFruitOrVegetable(String.valueOf(output)), "invalid output: " + output);
+            }
+        }
+        assertEquals(2, numRootSpans.get(), "each case should make a root span");
+        assertEquals(
+                numRootSpans.get() * 3, spans.size(), "each eval case should make three spans");
+    }
+
+    boolean isFruitOrVegetable(String str) {
+        return "vegetable".equals(str) || "fruit".equals(str);
     }
 }


### PR DESCRIPTION
- datasets interface
  - currently only in-memory datasets, but future proof for fetching from Braintrust
- task and scorers output to record classes
  - to support passing secondary data