### PR TITLE
add option to configure braintrust SDK json object mapper

### DIFF
--- a/src/main/java/dev/braintrust/instrumentation/anthropic/otel/BraintrustAnthropicSpanAttributes.java
+++ b/src/main/java/dev/braintrust/instrumentation/anthropic/otel/BraintrustAnthropicSpanAttributes.java
@@ -1,15 +1,14 @@
 package dev.braintrust.instrumentation.anthropic.otel;
 
+import static dev.braintrust.json.BraintrustJsonMapper.toJson;
+
 import com.anthropic.models.messages.Message;
 import com.anthropic.models.messages.MessageParam;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.opentelemetry.api.trace.Span;
 import java.util.List;
-import lombok.SneakyThrows;
 
 /** Centralized class for setting all Anthropic-related span attributes. */
 final class BraintrustAnthropicSpanAttributes {
-    private static final ObjectMapper JSON_MAPPER = new ObjectMapper();
 
     // GenAI semantic convention constants
     static final String OPERATION_CHAT = "chat";
@@ -21,25 +20,22 @@ final class BraintrustAnthropicSpanAttributes {
      * Sets the braintrust.input_json attribute with the input messages. This captures the user's
      * prompt and system messages before sending to Anthropic.
      */
-    @SneakyThrows
     public static void setInputMessages(Span span, List<MessageParam> messages) {
-        span.setAttribute("braintrust.input_json", JSON_MAPPER.writeValueAsString(messages));
+        span.setAttribute("braintrust.input_json", toJson(messages));
     }
 
     /**
      * Sets the braintrust.output_json attribute with the output message. This captures the
      * assistant's response from Anthropic.
      */
-    @SneakyThrows
     public static void setOutputMessage(Span span, Message message) {
-        span.setAttribute("braintrust.output_json", JSON_MAPPER.writeValueAsString(message));
+        span.setAttribute("braintrust.output_json", toJson(message));
     }
 
     /**
      * Sets the braintrust.output_json attribute with a JSON array. This is used for streaming
      * responses where the output is built incrementally.
      */
-    @SneakyThrows
     public static void setOutputJson(Span span, String outputJson) {
         span.setAttribute("braintrust.output_json", outputJson);
     }

--- a/src/main/java/dev/braintrust/instrumentation/anthropic/otel/StreamListener.java
+++ b/src/main/java/dev/braintrust/instrumentation/anthropic/otel/StreamListener.java
@@ -1,14 +1,16 @@
 package dev.braintrust.instrumentation.anthropic.otel;
 
+import static dev.braintrust.json.BraintrustJsonMapper.toJson;
+
 import com.anthropic.models.messages.Message;
 import com.anthropic.models.messages.MessageCreateParams;
 import com.anthropic.models.messages.MessageDeltaUsage;
 import com.anthropic.models.messages.Model;
 import com.anthropic.models.messages.RawMessageStreamEvent;
 import com.anthropic.models.messages.Usage;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import dev.braintrust.json.BraintrustJsonMapper;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.context.Context;
@@ -19,7 +21,6 @@ import javax.annotation.Nullable;
 import lombok.SneakyThrows;
 
 final class StreamListener {
-    private static final ObjectMapper JSON_MAPPER = new ObjectMapper();
 
     private final Context context;
     private final MessageCreateParams request;
@@ -93,14 +94,14 @@ final class StreamListener {
 
         // Handle content_block_stop - write output
         if (event.contentBlockStop().isPresent()) {
-            ArrayNode outputArray = JSON_MAPPER.createArrayNode();
-            ObjectNode message = JSON_MAPPER.createObjectNode();
+            ArrayNode outputArray = BraintrustJsonMapper.get().createArrayNode();
+            ObjectNode message = BraintrustJsonMapper.get().createObjectNode();
             message.put("role", "assistant");
             message.put("content", contentBuilder.toString());
             outputArray.add(message);
 
             BraintrustAnthropicSpanAttributes.setOutputJson(
-                    Span.fromContext(context), JSON_MAPPER.writeValueAsString(outputArray));
+                    Span.fromContext(context), toJson(outputArray));
         }
     }
 

--- a/src/main/java/dev/braintrust/instrumentation/openai/otel/BraintrustOAISpanAttributes.java
+++ b/src/main/java/dev/braintrust/instrumentation/openai/otel/BraintrustOAISpanAttributes.java
@@ -5,7 +5,6 @@
 
 package dev.braintrust.instrumentation.openai.otel;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.openai.models.chat.completions.ChatCompletion;
 import io.opentelemetry.api.trace.Span;
 import lombok.SneakyThrows;
@@ -14,7 +13,6 @@ import lombok.extern.slf4j.Slf4j;
 /** Centralized class for setting all OpenAI-related span attributes. */
 @Slf4j
 final class BraintrustOAISpanAttributes {
-    private static final ObjectMapper JSON_MAPPER = new ObjectMapper();
 
     // GenAI semantic convention constants
     static final String OPERATION_CHAT = "chat";

--- a/src/main/java/dev/braintrust/instrumentation/openai/otel/GenAiSemconvSerializer.java
+++ b/src/main/java/dev/braintrust/instrumentation/openai/otel/GenAiSemconvSerializer.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.openai.models.chat.completions.*;
+import dev.braintrust.json.BraintrustJsonMapper;
 import dev.braintrust.trace.Base64Attachment;
 import java.io.IOException;
 import java.lang.invoke.MethodHandle;
@@ -30,8 +31,8 @@ final class GenAiSemconvSerializer {
     private static ObjectMapper createObjectMapper() {
         final JsonSerializer<Base64Attachment> attachmentSerializer =
                 Base64Attachment.createSerializer();
-        ObjectMapper mapper = new ObjectMapper();
-        mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+        // Start with the base mapper configuration and add OpenAI-specific serializers
+        ObjectMapper mapper = BraintrustJsonMapper.get().copy();
         SimpleModule module = new SimpleModule();
         module.addSerializer(
                 ChatCompletionContentPartImage.class,

--- a/src/main/java/dev/braintrust/json/BraintrustJsonMapper.java
+++ b/src/main/java/dev/braintrust/json/BraintrustJsonMapper.java
@@ -1,0 +1,78 @@
+package dev.braintrust.json;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+import lombok.SneakyThrows;
+
+/** Centralized ObjectMapper for the Braintrust SDK. */
+public final class BraintrustJsonMapper {
+
+    private static volatile ObjectMapper instance;
+    private static final List<Consumer<ObjectMapper>> configurers = new ArrayList<>();
+    private static volatile boolean initialized = false;
+
+    /** Default configuration applied to all ObjectMapper instances. */
+    private static final Consumer<ObjectMapper> DEFAULT_CONFIG =
+            objectMapper -> {
+                objectMapper
+                        .registerModule(new JavaTimeModule())
+                        .registerModule(new Jdk8Module())
+                        .setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE)
+                        .setDefaultPropertyInclusion(JsonInclude.Include.NON_ABSENT)
+                        .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+            };
+
+    static {
+        configurers.add(DEFAULT_CONFIG);
+    }
+
+    private BraintrustJsonMapper() {}
+
+    public static ObjectMapper get() {
+        if (instance == null) {
+            synchronized (BraintrustJsonMapper.class) {
+                if (instance == null) {
+                    instance = new ObjectMapper();
+                    for (Consumer<ObjectMapper> configurer : configurers) {
+                        configurer.accept(instance);
+                    }
+                    initialized = true;
+                }
+            }
+        }
+        return instance;
+    }
+
+    public static synchronized void configure(Consumer<ObjectMapper> configurer) {
+        if (initialized) {
+            throw new IllegalStateException(
+                    "BraintrustJsonMapper has already been initialized. "
+                            + "configure() must be called before the first call to get().");
+        }
+        configurers.add(configurer);
+    }
+
+    @SneakyThrows
+    public static String toJson(Object o) {
+        return get().writeValueAsString(o);
+    }
+
+    @SneakyThrows
+    public static <T> T fromJson(String jsonString, Class<T> targetClass) {
+        return get().readValue(jsonString, targetClass);
+    }
+
+    static synchronized void reset() {
+        instance = null;
+        configurers.clear();
+        configurers.add(DEFAULT_CONFIG); // Re-add default configuration
+        initialized = false;
+    }
+}

--- a/src/test/java/dev/braintrust/eval/EvalTest.java
+++ b/src/test/java/dev/braintrust/eval/EvalTest.java
@@ -1,8 +1,9 @@
 package dev.braintrust.eval;
 
+import static dev.braintrust.json.BraintrustJsonMapper.fromJson;
+import static dev.braintrust.json.BraintrustJsonMapper.toJson;
 import static org.junit.jupiter.api.Assertions.*;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.braintrust.Origin;
 import dev.braintrust.TestHarness;
 import dev.braintrust.api.BraintrustApiClient;
@@ -19,8 +20,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class EvalTest {
-    private static final ObjectMapper JSON_MAPPER =
-            new com.fasterxml.jackson.databind.ObjectMapper();
     private TestHarness testHarness;
 
     @BeforeEach
@@ -74,21 +73,21 @@ public class EvalTest {
             if (span.getParentSpanId().equals(SpanId.getInvalid())) {
                 numRootSpans.incrementAndGet();
                 var inputJson =
-                        Eval.JSON_MAPPER.readValue(
+                        fromJson(
                                 span.getAttributes()
                                         .get(AttributeKey.stringKey("braintrust.input_json")),
                                 Map.class);
                 assertNotNull(inputJson.get("input"), "invlaid input: " + inputJson);
 
                 var expected =
-                        Eval.JSON_MAPPER.readValue(
+                        fromJson(
                                 span.getAttributes()
                                         .get(AttributeKey.stringKey("braintrust.expected")),
                                 String.class);
                 assertTrue(isFruitOrVegetable(expected), "invalid expected: " + expected);
 
                 var outputJson =
-                        Eval.JSON_MAPPER.readValue(
+                        fromJson(
                                 span.getAttributes()
                                         .get(AttributeKey.stringKey("braintrust.output_json")),
                                 Map.class);
@@ -249,14 +248,13 @@ public class EvalTest {
                 var inputJson =
                         span.getAttributes().get(AttributeKey.stringKey("braintrust.input_json"));
                 assertNotNull(inputJson);
-                JSON_MAPPER.readValue(inputJson, Map.class);
-                var input = (String) (JSON_MAPPER.readValue(inputJson, Map.class)).get("input");
+                fromJson(inputJson, Map.class);
+                var input = (String) (fromJson(inputJson, Map.class)).get("input");
                 assertNotNull(input);
                 var origin = span.getAttributes().get(AttributeKey.stringKey("braintrust.origin"));
                 switch (input) {
                     case "no-origin" -> assertNull(origin);
-                    case "has-origin" ->
-                            assertEquals(JSON_MAPPER.writeValueAsString(testOrigin), origin);
+                    case "has-origin" -> assertEquals(toJson(testOrigin), origin);
                     default -> fail("unexpected input: " + input);
                 }
                 numRootSpans.incrementAndGet();

--- a/src/test/java/dev/braintrust/json/BraintrustJsonMapperTest.java
+++ b/src/test/java/dev/braintrust/json/BraintrustJsonMapperTest.java
@@ -1,0 +1,145 @@
+package dev.braintrust.json;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.fasterxml.jackson.databind.SerializationFeature;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+class BraintrustJsonMapperTest {
+
+    @AfterEach
+    void tearDown() {
+        BraintrustJsonMapper.reset();
+    }
+
+    @Test
+    void toJson_serializesObject() {
+        record Person(String name, int age) {}
+
+        String json = BraintrustJsonMapper.toJson(new Person("Alice", 30));
+
+        assertEquals("{\"name\":\"Alice\",\"age\":30}", json);
+    }
+
+    @Test
+    void fromJson_deserializesObject() {
+        record Person(String name, int age) {}
+
+        Person person =
+                BraintrustJsonMapper.fromJson("{\"name\":\"Bob\",\"age\":25}", Person.class);
+
+        assertEquals("Bob", person.name());
+        assertEquals(25, person.age());
+    }
+
+    @Test
+    void toJson_handlesJavaTimeModule() {
+        var instant = Instant.parse("2024-01-15T10:30:00Z");
+
+        String json = BraintrustJsonMapper.toJson(instant);
+
+        // JavaTimeModule serializes Instant as a number by default
+        assertNotNull(json);
+        assertFalse(json.contains("Instant")); // Not toString() output
+    }
+
+    @Test
+    void toJson_handlesJdk8ModuleWithOptional() {
+        record TestRecord(String name, Optional<String> nickname) {}
+
+        // Present Optional
+        var withNickname = new TestRecord("Alice", Optional.of("Ali"));
+        String json1 = BraintrustJsonMapper.toJson(withNickname);
+        assertTrue(json1.contains("\"nickname\":\"Ali\""));
+
+        // Empty Optional should be excluded (NON_ABSENT)
+        var withoutNickname = new TestRecord("Bob", Optional.empty());
+        String json2 = BraintrustJsonMapper.toJson(withoutNickname);
+        assertFalse(json2.contains("nickname"));
+    }
+
+    @Test
+    void toJson_excludesNullValues() {
+        record TestRecord(String name, String email) {}
+
+        String json = BraintrustJsonMapper.toJson(new TestRecord("Alice", null));
+
+        assertFalse(json.contains("email"));
+        assertTrue(json.contains("\"name\":\"Alice\""));
+    }
+
+    @Test
+    void fromJson_ignoresUnknownProperties() {
+        record TestRecord(String name) {}
+
+        var record =
+                BraintrustJsonMapper.fromJson(
+                        "{\"name\":\"Alice\",\"unknownField\":123}", TestRecord.class);
+
+        assertEquals("Alice", record.name());
+    }
+
+    @Test
+    void configure_appliesConfiguration() {
+        AtomicBoolean configurerCalled = new AtomicBoolean(false);
+
+        BraintrustJsonMapper.configure(
+                mapper -> {
+                    configurerCalled.set(true);
+                    mapper.enable(SerializationFeature.INDENT_OUTPUT);
+                });
+
+        var mapper = BraintrustJsonMapper.get();
+
+        assertTrue(configurerCalled.get());
+        assertTrue(mapper.isEnabled(SerializationFeature.INDENT_OUTPUT));
+    }
+
+    @Test
+    void configure_throwsIfCalledAfterGet() {
+        BraintrustJsonMapper.get(); // Initialize
+
+        assertThrows(
+                IllegalStateException.class, () -> BraintrustJsonMapper.configure(mapper -> {}));
+    }
+
+    @Test
+    void configure_allowsMultipleConfigurers() {
+        BraintrustJsonMapper.configure(mapper -> mapper.enable(SerializationFeature.INDENT_OUTPUT));
+
+        BraintrustJsonMapper.configure(
+                mapper -> mapper.enable(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS));
+
+        var mapper = BraintrustJsonMapper.get();
+
+        assertTrue(mapper.isEnabled(SerializationFeature.INDENT_OUTPUT));
+        assertTrue(mapper.isEnabled(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS));
+    }
+
+    @Test
+    void roundTrip_objectEqualsAfterSerializationAndDeserialization() {
+        record Person(String name, int age, Optional<String> email) {}
+
+        var original = new Person("Alice", 30, Optional.of("alice@example.com"));
+
+        String json = BraintrustJsonMapper.toJson(original);
+        Person restored = BraintrustJsonMapper.fromJson(json, Person.class);
+
+        assertEquals(original, restored);
+    }
+
+    @Test
+    void toJson_usesSnakeCaseNaming() {
+        record UserProfile(String firstName, String lastName, int totalScore) {}
+
+        String json = BraintrustJsonMapper.toJson(new UserProfile("Alice", "Smith", 100));
+
+        assertTrue(json.contains("\"first_name\":\"Alice\""));
+        assertTrue(json.contains("\"last_name\":\"Smith\""));
+        assertTrue(json.contains("\"total_score\":100"));
+    }
+}


### PR DESCRIPTION
- add a global object mapper for json ser/de
- plus optional hooks to configure the global mapper

```
// called once at app startup
BraintrustJsonMapper.configure(objectMapper -> {
    // mutate the global braintrust object mapper here
});
```