### PR TITLE
fix: wire BraintrustConfig.sslContext into the API HTTP client

### DIFF
--- a/braintrust-sdk/src/main/java/dev/braintrust/api/BraintrustApiClient.java
+++ b/braintrust-sdk/src/main/java/dev/braintrust/api/BraintrustApiClient.java
@@ -485,7 +485,10 @@ public interface BraintrustApiClient {
         }
 
         private static HttpClient createDefaultHttpClient(BraintrustConfig config) {
-            return HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(10)).build();
+            return HttpClient.newBuilder()
+                    .connectTimeout(Duration.ofSeconds(10))
+                    .sslContext(config.sslContext())
+                    .build();
         }
     }
 


### PR DESCRIPTION
BraintrustConfig already accepted a custom SSLContext via its builder and applied it to the OTLP span exporter, but createDefaultHttpClient ignored it — leaving BraintrustApiClient always using the JVM default trust store. Customers with custom CAs or internal PKI hit certificate validation errors with no way to override them.

This came from customer feedback:

> One additional issue I ran into on [braintrust-sdk-java](https://github.com/braintrustdata/braintrust-sdk-java) was around BraintrustApiClient SSL configuration.  In our environment, we needed to customize the SSL context, but the current BraintrustApiClient abstraction did not seem to expose a straightforward way to inject or override it.  This led to some certificate validation issues in our setup.