### PR TITLE
feat: Upwards-recursively read `.env.braintrust` containing `BRAINTRUST_API_KEY`

### DIFF
--- a/braintrust-sdk/src/main/java/dev/braintrust/config/BraintrustApiKey.java
+++ b/braintrust-sdk/src/main/java/dev/braintrust/config/BraintrustApiKey.java
@@ -1,0 +1,250 @@
+package dev.braintrust.config;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.atomic.AtomicReferenceArray;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import javax.annotation.Nullable;
+
+final class BraintrustApiKey {
+    static final String ENV_VAR = "BRAINTRUST_API_KEY";
+    private static final String ENV_FILE = ".env.braintrust";
+    private static final int SEARCH_PARENT_LIMIT = 64;
+
+    private static volatile Function<String, String> getenv = System::getenv;
+    private static volatile Supplier<Path> cwd =
+            () -> Path.of(System.getProperty("user.dir", ".")).toAbsolutePath().normalize();
+
+    private final Map<String, String> envOverrides;
+    private final AtomicReference<CompletableFuture<Optional<String>>> envFileApiKey =
+            new AtomicReference<>();
+
+    BraintrustApiKey(Map<String, String> envOverrides) {
+        this.envOverrides = envOverrides;
+    }
+
+    String getRequired() {
+        var apiKey = get();
+        if (apiKey == null) {
+            throw new RuntimeException("%s is required".formatted(ENV_VAR));
+        }
+        return apiKey;
+    }
+
+    private @Nullable String get() {
+        if (envOverrides.containsKey(ENV_VAR)) {
+            var override = envOverrides.get(ENV_VAR);
+            return BaseConfig.NULL_OVERRIDE.equals(override) ? null : override;
+        }
+
+        var envValue = getEnvironmentValue();
+        if (envValue != null && !envValue.trim().isEmpty()) {
+            return envValue;
+        }
+
+        return getEnvFileApiKeyFuture().join().orElse(null);
+    }
+
+    private static @Nullable String getEnvironmentValue() {
+        try {
+            return getenv.apply(ENV_VAR);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private CompletableFuture<Optional<String>> getEnvFileApiKeyFuture() {
+        var existing = envFileApiKey.get();
+        if (existing != null) {
+            return existing;
+        }
+
+        var created = findEnvFileApiKeyAsync();
+        if (envFileApiKey.compareAndSet(null, created)) {
+            return created;
+        }
+        var winner = envFileApiKey.get();
+        return winner != null ? winner : created;
+    }
+
+    private static CompletableFuture<Optional<String>> findEnvFileApiKeyAsync() {
+        Path start;
+        try {
+            start = cwd.get();
+        } catch (Exception e) {
+            return CompletableFuture.completedFuture(Optional.empty());
+        }
+
+        var candidates = envFileCandidates(start);
+        if (candidates.isEmpty()) {
+            return CompletableFuture.completedFuture(Optional.empty());
+        }
+
+        var result = new CompletableFuture<Optional<String>>();
+        var readResults = new AtomicReferenceArray<ReadResult>(candidates.size());
+        var lock = new Object();
+
+        for (int i = 0; i < candidates.size(); i++) {
+            var index = i;
+            var candidate = candidates.get(i);
+            CompletableFuture.supplyAsync(() -> readEnvFile(candidate, index))
+                    .whenComplete(
+                            (readResult, error) -> {
+                                var normalizedResult =
+                                        error == null
+                                                ? readResult
+                                                : new ReadResult(index, null, false);
+                                synchronized (lock) {
+                                    if (result.isDone()) {
+                                        return;
+                                    }
+                                    readResults.set(index, normalizedResult);
+                                    completeIfResolved(readResults, result);
+                                }
+                            });
+        }
+
+        return result;
+    }
+
+    private static ArrayList<Path> envFileCandidates(Path start) {
+        var candidates = new ArrayList<Path>();
+        var dir = start;
+        for (int depth = 0; depth <= SEARCH_PARENT_LIMIT && dir != null; depth++) {
+            candidates.add(dir.resolve(ENV_FILE));
+            var parent = dir.getParent();
+            if (parent == null || parent.equals(dir)) {
+                break;
+            }
+            dir = parent;
+        }
+        return candidates;
+    }
+
+    private static ReadResult readEnvFile(Path envFile, int index) {
+        try {
+            return new ReadResult(index, Files.readString(envFile, StandardCharsets.UTF_8), false);
+        } catch (NoSuchFileException e) {
+            return new ReadResult(index, null, true);
+        } catch (IOException | RuntimeException e) {
+            return new ReadResult(index, null, false);
+        }
+    }
+
+    private static void completeIfResolved(
+            AtomicReferenceArray<ReadResult> readResults,
+            CompletableFuture<Optional<String>> result) {
+        for (int i = 0; i < readResults.length(); i++) {
+            var readResult = readResults.get(i);
+            if (readResult == null) {
+                return;
+            }
+            if (readResult.missing()) {
+                continue;
+            }
+            if (readResult.contents() != null) {
+                result.complete(parseApiKey(readResult.contents()));
+            } else {
+                result.complete(Optional.empty());
+            }
+            return;
+        }
+        result.complete(Optional.empty());
+    }
+
+    static Optional<String> parseApiKey(String contents) {
+        String value = null;
+        for (var line : contents.split("\\R", -1)) {
+            var parsed = parseLine(line);
+            if (parsed != null) {
+                value = parsed;
+            }
+        }
+        return value != null && !value.trim().isEmpty() ? Optional.of(value) : Optional.empty();
+    }
+
+    private static @Nullable String parseLine(String line) {
+        var text = line.strip();
+        if (text.isEmpty() || text.startsWith("#")) {
+            return null;
+        }
+
+        if (text.startsWith("export")
+                && text.length() > "export".length()
+                && Character.isWhitespace(text.charAt("export".length()))) {
+            text = text.substring("export".length()).stripLeading();
+        }
+
+        var equalsIndex = text.indexOf('=');
+        if (equalsIndex <= 0) {
+            return null;
+        }
+
+        var key = text.substring(0, equalsIndex).trim();
+        if (!ENV_VAR.equals(key)) {
+            return null;
+        }
+
+        return parseValue(text.substring(equalsIndex + 1).stripLeading());
+    }
+
+    private static String parseValue(String rawValue) {
+        if (rawValue.isEmpty()) {
+            return "";
+        }
+
+        var quote = rawValue.charAt(0);
+        if (quote == '"' || quote == '\'') {
+            return parseQuotedValue(rawValue, quote);
+        }
+
+        var commentIndex = rawValue.indexOf('#');
+        var value = commentIndex >= 0 ? rawValue.substring(0, commentIndex) : rawValue;
+        return value.trim();
+    }
+
+    private static String parseQuotedValue(String rawValue, char quote) {
+        var value = new StringBuilder();
+        for (int i = 1; i < rawValue.length(); i++) {
+            var c = rawValue.charAt(i);
+            if (c == quote) {
+                return value.toString();
+            }
+            if (quote == '"' && c == '\\' && i + 1 < rawValue.length()) {
+                var next = rawValue.charAt(++i);
+                switch (next) {
+                    case 'n' -> value.append('\n');
+                    case 'r' -> value.append('\r');
+                    case 't' -> value.append('\t');
+                    default -> value.append(next);
+                }
+            } else {
+                value.append(c);
+            }
+        }
+        return value.toString();
+    }
+
+    static AutoCloseable useTestLookup(
+            Function<String, String> testGetenv, Supplier<Path> testCwd) {
+        var previousGetenv = getenv;
+        var previousCwd = cwd;
+        getenv = testGetenv;
+        cwd = testCwd;
+        return () -> {
+            getenv = previousGetenv;
+            cwd = previousCwd;
+        };
+    }
+
+    private record ReadResult(int index, String contents, boolean missing) {}
+}

--- a/braintrust-sdk/src/main/java/dev/braintrust/config/BraintrustConfig.java
+++ b/braintrust-sdk/src/main/java/dev/braintrust/config/BraintrustConfig.java
@@ -24,7 +24,7 @@ import lombok.experimental.Accessors;
 @Getter
 @Accessors(fluent = true)
 public final class BraintrustConfig extends BaseConfig {
-    private final String apiKey = getRequiredConfig("BRAINTRUST_API_KEY");
+    private final BraintrustApiKey apiKey = new BraintrustApiKey(envOverrides);
     private final String apiUrl = getConfig("BRAINTRUST_API_URL", "https://api.braintrust.dev");
     private final String appUrl = getConfig("BRAINTRUST_APP_URL", "https://www.braintrust.dev");
     private final String tracesPath = getConfig("BRAINTRUST_TRACES_PATH", "/otel/v1/traces");
@@ -66,6 +66,10 @@ public final class BraintrustConfig extends BaseConfig {
 
     public static BraintrustConfig fromEnvironment() {
         return of();
+    }
+
+    public String apiKey() {
+        return apiKey.getRequired();
     }
 
     public static BraintrustConfig of(String... envOverrides) {

--- a/braintrust-sdk/src/test/java/dev/braintrust/config/BraintrustApiKeyTest.java
+++ b/braintrust-sdk/src/test/java/dev/braintrust/config/BraintrustApiKeyTest.java
@@ -1,0 +1,154 @@
+package dev.braintrust.config;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class BraintrustApiKeyTest {
+    @TempDir private Path tempDir;
+
+    @Test
+    void explicitApiKeyWinsOverEnvironmentAndEnvFile() throws Exception {
+        writeBraintrustEnv(tempDir, "BRAINTRUST_API_KEY=file-key\n");
+
+        try (var ignored = useLookup(Map.of("BRAINTRUST_API_KEY", "env-key"), tempDir)) {
+            var config = BraintrustConfig.builder().apiKey("explicit-key").build();
+
+            assertEquals("explicit-key", config.apiKey());
+        }
+    }
+
+    @Test
+    void nonblankEnvironmentApiKeyWinsOverEnvFile() throws Exception {
+        writeBraintrustEnv(tempDir, "BRAINTRUST_API_KEY=file-key\n");
+
+        try (var ignored = useLookup(Map.of("BRAINTRUST_API_KEY", "env-key"), tempDir)) {
+            var config = BraintrustConfig.fromEnvironment();
+
+            assertEquals("env-key", config.apiKey());
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", "   "})
+    void blankEnvironmentApiKeyFallsBackToEnvFile(String envValue) throws Exception {
+        writeBraintrustEnv(tempDir, "BRAINTRUST_API_KEY=file-key\n");
+
+        try (var ignored = useLookup(Map.of("BRAINTRUST_API_KEY", envValue), tempDir)) {
+            var config = BraintrustConfig.fromEnvironment();
+
+            assertEquals("file-key", config.apiKey());
+        }
+    }
+
+    @Test
+    void findsNearestParentEnvFile() throws Exception {
+        var packageDir = tempDir.resolve("packages");
+        var appDir = packageDir.resolve("app");
+        Files.createDirectories(appDir);
+        writeBraintrustEnv(tempDir, "BRAINTRUST_API_KEY=root-key\n");
+        writeBraintrustEnv(packageDir, "BRAINTRUST_API_KEY=package-key\n");
+
+        try (var ignored = useLookup(Map.of(), appDir)) {
+            var config = BraintrustConfig.fromEnvironment();
+
+            assertEquals("package-key", config.apiKey());
+        }
+    }
+
+    @Test
+    void envFileLookupUsesCwdWhenApiKeyIsRequested() throws Exception {
+        var config = BraintrustConfig.fromEnvironment();
+        writeBraintrustEnv(tempDir, "BRAINTRUST_API_KEY=file-key\n");
+
+        try (var ignored = useLookup(Map.of(), tempDir)) {
+            assertEquals("file-key", config.apiKey());
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"OTHER=value\n", "BRAINTRUST_API_KEY=\"   \"\n"})
+    void nearestEnvFileWithoutNonblankApiKeyStopsSearch(String nearestContents) throws Exception {
+        var packageDir = tempDir.resolve("packages");
+        var appDir = packageDir.resolve("app");
+        Files.createDirectories(appDir);
+        writeBraintrustEnv(tempDir, "BRAINTRUST_API_KEY=root-key\n");
+        writeBraintrustEnv(packageDir, nearestContents);
+
+        try (var ignored = useLookup(Map.of(), appDir)) {
+            var config = BraintrustConfig.fromEnvironment();
+
+            assertThrows(RuntimeException.class, config::apiKey);
+        }
+    }
+
+    @Test
+    void unreadableNearestEnvFileStopsSearch() throws Exception {
+        var packageDir = tempDir.resolve("packages");
+        var appDir = packageDir.resolve("app");
+        Files.createDirectories(appDir);
+        writeBraintrustEnv(tempDir, "BRAINTRUST_API_KEY=root-key\n");
+        Files.createDirectory(packageDir.resolve(".env.braintrust"));
+
+        try (var ignored = useLookup(Map.of(), appDir)) {
+            var config = BraintrustConfig.fromEnvironment();
+
+            assertThrows(RuntimeException.class, config::apiKey);
+        }
+    }
+
+    @Test
+    void searchesCwdAndAtMost64Parents() throws Exception {
+        var nested = tempDir;
+        for (int i = 0; i < 65; i++) {
+            nested = nested.resolve("d" + i);
+        }
+        Files.createDirectories(nested);
+        writeBraintrustEnv(tempDir, "BRAINTRUST_API_KEY=too-high\n");
+
+        try (var ignored = useLookup(Map.of(), nested)) {
+            var config = BraintrustConfig.fromEnvironment();
+
+            assertThrows(RuntimeException.class, config::apiKey);
+        }
+
+        writeBraintrustEnv(tempDir.resolve("d0"), "BRAINTRUST_API_KEY=boundary-key\n");
+        try (var ignored = useLookup(Map.of(), nested)) {
+            var config = BraintrustConfig.fromEnvironment();
+
+            assertEquals("boundary-key", config.apiKey());
+        }
+    }
+
+    @Test
+    void supportsDotenvSyntaxAndIgnoresOtherVariables() throws Exception {
+        writeBraintrustEnv(
+                tempDir,
+                """
+                BRAINTRUST_DOTENV_ONLY_TEST_VAR=value
+                export BRAINTRUST_API_KEY="quoted-key" # comment
+                """);
+
+        try (var ignored = useLookup(Map.of(), tempDir)) {
+            var config = BraintrustConfig.fromEnvironment();
+
+            assertEquals("quoted-key", config.apiKey());
+            assertNull(config.getEnvValue("BRAINTRUST_DOTENV_ONLY_TEST_VAR"));
+        }
+    }
+
+    private void writeBraintrustEnv(Path dir, String contents) throws Exception {
+        Files.createDirectories(dir);
+        Files.writeString(dir.resolve(".env.braintrust"), contents);
+    }
+
+    private AutoCloseable useLookup(Map<String, String> env, Path cwd) {
+        return BraintrustApiKey.useTestLookup(env::get, () -> cwd);
+    }
+}


### PR DESCRIPTION
Direct port of https://github.com/braintrustdata/braintrust-sdk-javascript/pull/2049

Prompt used:

```
Implement `.env.braintrust` API key discovery for this Braintrust SDK.

Context:
The Braintrust instrumentation wizard will generate a file named `.env.braintrust` in the user’s current working directory. That file contains a dotenv-style `BRAINTRUST_API_KEY=...` entry. The goal is that after running the wizard, users can immediately run or verify local Braintrust instrumentation without manually exporting `BRAINTRUST_API_KEY`.

`.env.braintrust` is not a general dotenv loader. It is only a credential fallback for Braintrust SDK API-key lookup.

Required behavior:
- Preserve precedence:
  1. Explicit caller-provided API key wins.
  2. Nonblank `BRAINTRUST_API_KEY` from the process environment wins.
  3. Otherwise, read `BRAINTRUST_API_KEY` from `.env.braintrust`.
- Treat missing, empty, or whitespace-only environment values as unset.
- Look for `.env.braintrust` starting at the current working directory at lookup time, then walk upward.
- Cap lookup at cwd plus 64 parent directories.
- The nearest `.env.braintrust` wins.
- The nearest `.env.braintrust` is a boundary: if it exists but has no nonblank `BRAINTRUST_API_KEY`, do not check higher parents.
- If the nearest `.env.braintrust` cannot be read, return “not found” and do not check higher parents. Do not throw from credential discovery.
- Read only `BRAINTRUST_API_KEY`; do not load or expose other variables from the file.
- Do not mutate the process environment.
- Support normal dotenv syntax if the SDK/runtime has a standard parser: quotes, comments, and `export BRAINTRUST_API_KEY=...`.

Implementation guidance:
- Prefer lazy, nonblocking lookup.
- If possible, start candidate file reads in parallel, but preserve nearest-wins semantics: a higher parent may only win after all closer candidates are known absent.
- If a constructor/setup path is synchronous, do not add blocking file IO there.
- For telemetry/exporter integrations, make export/flush wait for API-key discovery when needed.

Look at the reference implementation PR: https://github.com/braintrustdata/braintrust-sdk-javascript/pull/2049
```