### PR TITLE
Wire OpenTelemetry into ClassifiersExample

### DIFF
--- a/examples/classifiers/src/main/java/dev/braintrust/examples/ClassifiersExample.java
+++ b/examples/classifiers/src/main/java/dev/braintrust/examples/ClassifiersExample.java
@@ -26,6 +26,7 @@ import java.util.List;
 public class ClassifiersExample {
     public static void main(String[] args) throws Exception {
         var braintrust = Braintrust.get();
+        braintrust.openTelemetryCreate();
 
         // 1. Single-label classifier.
         Classifier<String, String> intentClassifier =


### PR DESCRIPTION
## Summary

- Add the missing `braintrust.openTelemetryCreate()` call to `ClassifiersExample` so spans actually reach Braintrust. Every other example already does this immediately after `Braintrust.get()`.

## Background

When the classifier feature merged (#114) and the examples were subsequently reorganised into per-example subprojects (#116), `ClassifiersExample` was the only example left without an explicit OpenTelemetry initialisation. As a result, running `./gradlew :examples:classifiers:run` would create the experiment via REST but the eval spans would land on the no-op tracer and never be exported, leaving the experiment empty in the UI.

## Test plan

- [x] `./gradlew :examples:classifiers:run` against the `Braintrust SDKs` org — printed experiment now contains five root spans (BTQL `count(_xact_id)` returns 5).
- [x] `VCR_MODE=replay ./gradlew :braintrust-sdk:test --tests '*ClassifierEvalTest*'` — no regression.

> Note: the new rows currently land with `classifications: null` because the api-ts OTEL ingestion doesn't yet recognise `braintrust.classifications` — the JSON falls through to row metadata. That gap is being addressed separately in the braintrust monorepo. This PR is strictly the SDK-side fix that gets the spans flowing at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)