### PR TITLE
fix: DatasetCase.metadata() always empty when fetching dataset rows from Braintrust

### DIFF
--- a/braintrust-sdk/src/main/java/dev/braintrust/eval/DatasetBrainstoreImpl.java
+++ b/braintrust-sdk/src/main/java/dev/braintrust/eval/DatasetBrainstoreImpl.java
@@ -118,9 +118,18 @@ public class DatasetBrainstoreImpl<INPUT, OUTPUT> implements Dataset<INPUT, OUTP
             OUTPUT expected = (OUTPUT) event.getExpected();
 
             var metadataObj = event.getMetadata();
-            Map<String, Object> metadata =
-                    metadataObj != null ? metadataObj.getAdditionalProperties() : Map.of();
-            if (metadata == null) metadata = Map.of();
+            // InsertProjectLogsEventMetadata extends HashMap<String,Object>. Jackson stores
+            // unknown fields in the HashMap base (not in additionalProperties) for Map subclasses,
+            // so copy from both sources defensively.
+            Map<String, Object> metadata;
+            if (metadataObj != null) {
+                metadata = new HashMap<>(metadataObj);
+                if (metadataObj.getAdditionalProperties() != null) {
+                    metadata.putAll(metadataObj.getAdditionalProperties());
+                }
+            } else {
+                metadata = Map.of();
+            }
 
             List<String> tags = event.getTags() != null ? event.getTags() : List.of();
 

--- a/braintrust-sdk/src/test/java/dev/braintrust/eval/DatasetBrainstoreImplTest.java
+++ b/braintrust-sdk/src/test/java/dev/braintrust/eval/DatasetBrainstoreImplTest.java
@@ -222,6 +222,50 @@ public class DatasetBrainstoreImplTest {
     }
 
     @Test
+    void testMetadataPopulatedFromDatasetRow() {
+        wireMock.stubFor(
+                post(urlEqualTo("/v1/dataset/" + datasetId + "/fetch"))
+                        .willReturn(
+                                aResponse()
+                                        .withStatus(200)
+                                        .withHeader("Content-Type", "application/json")
+                                        .withBody(
+                                                """
+                                {
+                                  "events": [
+                                    {
+                                      "object_type": "dataset",
+                                      "dataset_id": "%s",
+                                      "id": "meta-row-1",
+                                      "_xact_id": "1",
+                                      "created": "2024-01-01T00:00:00Z",
+                                      "input": "test input",
+                                      "expected": "test output",
+                                      "metadata": {
+                                        "performance_strategy": "TURBO",
+                                        "userId": "user123"
+                                      }
+                                    }
+                                  ],
+                                  "cursor": null
+                                }
+                                """
+                                                        .formatted(datasetId))));
+
+        DatasetBrainstoreImpl<String, String> dataset =
+                new DatasetBrainstoreImpl<>(apiClient, datasetId, "test-version");
+
+        List<DatasetCase<String, String>> cases = new ArrayList<>();
+        dataset.forEach(cases::add);
+
+        assertEquals(1, cases.size());
+        Map<String, Object> metadata = cases.get(0).metadata();
+        assertFalse(metadata.isEmpty(), "metadata should not be empty");
+        assertEquals("TURBO", metadata.get("performance_strategy"));
+        assertEquals("user123", metadata.get("userId"));
+    }
+
+    @Test
     void testFetchFromBraintrustNotFound() {
         String projectName = "test-project";
         String datasetName = "nonexistent";


### PR DESCRIPTION
Fixes #125

## Problem

When running a remote eval that fetches dataset rows from Braintrust (e.g. a dataset assigned in the Playground UI), `DatasetCase.metadata()` returns an empty map for every row — even though the rows have metadata set. The same experiment works correctly with the TypeScript CLI.

## Root Cause

`InsertProjectLogsEventMetadata` extends `HashMap<String, Object>` and also declares a separate `additionalProperties` field. Jackson deserializes unknown properties (all custom metadata keys) into the `HashMap` base, **not** into the `additionalProperties` field. `DatasetBrainstoreImpl` was calling `metadataObj.getAdditionalProperties()`, which is always empty.

## Fix

Copy entries from the `HashMap` base via `new HashMap<>(metadataObj)` instead of calling `getAdditionalProperties()`.

```java
// Before:
Map<String, Object> metadata =
        metadataObj != null ? metadataObj.getAdditionalProperties() : Map.of();
if (metadata == null) metadata = Map.of();

// After:
Map<String, Object> metadata = metadataObj != null ? new HashMap<>(metadataObj) : Map.of();
```

## Verification

Confirmed by running a playground experiment against a Braintrust dataset with metadata fields. After the fix, `DatasetCase.metadata()` correctly returns the row's metadata keys. Before the fix, `metadata_keys=[]` for every dataset-fetched row.