### PR TITLE
update springai muzzle config

### DIFF
--- a/braintrust-sdk/instrumentation/springai_1_0_0/build.gradle
+++ b/braintrust-sdk/instrumentation/springai_1_0_0/build.gradle
@@ -4,7 +4,7 @@ muzzle {
   pass {
     group = 'org.springframework.ai'
     module = 'spring-ai-openai'
-    versions = "[${springAiVersion},)"
+    versions = "[${springAiVersion},2.0.0)"
     ignoredInstrumentation = ["dev.braintrust.instrumentation.springai.v1_0_0.auto.SpringAIAnthropicInstrumentationModule"]
     extraDependency 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
     extraDependency 'com.fasterxml.jackson.datatype:jackson-datatype-jdk8'
@@ -12,7 +12,7 @@ muzzle {
   pass {
     group = 'org.springframework.ai'
     module = 'spring-ai-anthropic'
-    versions = "[${springAiVersion},)"
+    versions = "[${springAiVersion},2.0.0)"
     ignoredInstrumentation = ["dev.braintrust.instrumentation.springai.v1_0_0.auto.SpringAIOpenAIInstrumentationModule"]
     extraDependency 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
     extraDependency 'com.fasterxml.jackson.datatype:jackson-datatype-jdk8'


### PR DESCRIPTION
springai 1.x instrumentation does not apply to 2.x. Will investigate 2.x instrumentation when it is prioritized in our roadmap. Updating 1.x muzzle directive to unblock the build